### PR TITLE
Directly spawn chrome driver process and fix retry logic

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -72,7 +72,7 @@ Application.prototype.startChromeDriver = function () {
           return resolve()
         } else if (tries >= 10) {
           clearInterval(timerID)
-          return reject('Could not get a response from ChromeDriver')
+          throw new Error('Could not get a response from ChromeDriver')
         }
         tries++
       })

--- a/lib/application.js
+++ b/lib/application.js
@@ -72,7 +72,7 @@ Application.prototype.startChromeDriver = function () {
           return resolve()
         } else if (tries >= 10) {
           clearInterval(timerID)
-          throw new Error('Could not get a response from ChromeDriver')
+          throw reject(Error('Could not get a response from ChromeDriver'))
         }
         tries++
       })

--- a/lib/application.js
+++ b/lib/application.js
@@ -72,7 +72,7 @@ Application.prototype.startChromeDriver = function () {
           return resolve()
         } else if (tries >= 10) {
           clearInterval(timerID)
-          return reject()
+          return reject('Could not get a response from ChromeDriver')
         }
         tries++
       })

--- a/lib/application.js
+++ b/lib/application.js
@@ -70,7 +70,7 @@ Application.prototype.startChromeDriver = function () {
         if (running) {
           clearInterval(timerID)
           return resolve()
-        } else if (tries >= 10) {
+        } else if (tries >= 100) {
           clearInterval(timerID)
           throw reject(Error('Could not get a response from ChromeDriver'))
         }

--- a/lib/application.js
+++ b/lib/application.js
@@ -64,13 +64,19 @@ Application.prototype.startChromeDriver = function () {
     self.chromeDriver = new ChromeDriver(self.host, self.port)
     self.chromeDriver.start()
 
-    var waitUntilRunning = function () {
+    var tries = 0;
+    var timerID = setInterval(function() {
       self.chromeDriver.isRunning(function (running) {
-        if (running) return resolve()
-        setTimeout(waitUntilRunning, 100)
-      })
-    }
-    waitUntilRunning()
+        if (running) {
+          clearInterval(timerID)
+          return resolve()
+        } else if (tries >= 10) {
+          clearInterval(timerID)
+          return reject()
+        }
+        tries++
+      });
+    }, 100)
   })
 }
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -64,8 +64,8 @@ Application.prototype.startChromeDriver = function () {
     self.chromeDriver = new ChromeDriver(self.host, self.port)
     self.chromeDriver.start()
 
-    var tries = 0;
-    var timerID = setInterval(function() {
+    var tries = 0
+    var timerID = setInterval(function () {
       self.chromeDriver.isRunning(function (running) {
         if (running) {
           clearInterval(timerID)
@@ -75,7 +75,7 @@ Application.prototype.startChromeDriver = function () {
           return reject()
         }
         tries++
-      });
+      })
     }, 100)
   })
 }

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -15,7 +15,6 @@ ChromeDriver.prototype.start = function () {
   if (this.process) throw new Error('ChromeDriver already started')
 
   var args = [
-    this.path,
     '--port=' + this.port,
     '--url-base=' + this.urlBase
   ]
@@ -24,7 +23,7 @@ ChromeDriver.prototype.start = function () {
     cwd: process.cwd(),
     env: this.getEnvironment()
   }
-  this.process = ChildProcess.spawn(process.execPath, args, options)
+  this.process = ChildProcess.spawn(this.path, args, options)
 
   var self = this
   this.exitHandler = function () { self.stop() }

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -23,7 +23,12 @@ ChromeDriver.prototype.start = function () {
     cwd: process.cwd(),
     env: this.getEnvironment()
   }
-  this.process = ChildProcess.spawn(this.path, args, options)
+
+  var pathToExecutable = this.path
+  if (process.platform === 'win32') {
+    pathToExecutable = process.execPath
+  }
+  this.process = ChildProcess.spawn(pathToExecutable, args, options)
 
   var self = this
   this.exitHandler = function () { self.stop() }


### PR DESCRIPTION
When I run a standalone spectron script using node, everything works as expected.  However, when I try to get spectron working inside my atom package, process.execPath is the atom helper binary, and this doesn't work.  Spawning the chromedriver process directly fixes this.

The setTimeout retry logic in `startChromeDriver` wasn't working for me either, so I replaced it with a setInterval and a max retry limit.  