### PR TITLE
Add startTimeout config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.35.5
+
+* Added a `startTimeout` config option to `Application` that sets the default
+  millisecond timeout to wait for ChromeDriver to start up. This option
+  defaults to 5 seconds.
+
 # 0.35.4
 
 * Added `getMainProcessGlobal` command helper to get a global from the main
@@ -16,7 +22,7 @@
 
 * Added a `waitTimeout` config option to `Application` that sets the default
   millisecond timeout for all wait-based command helpers like `waitUntil`,
-  `waitUntilWindowLoaded`, etc. This options defaults to 5 seconds.
+  `waitUntilWindowLoaded`, etc. This option defaults to 5 seconds.
 * Added a `windowByIndex(index)` command helper that focuses a window by
   index in the `windowHandles()` array order.
 * Added `setRepresentedFilename` and `getRepresentedFilename` command helpers.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Create a new application with the following options:
 * `quitTimeout` - Number in milliseconds to wait for application quitting.
   Defaults to `1000` milliseconds.
 * `startTimeout` - Number in milliseconds to wait for ChromeDriver to start.
-  Defaults to `10000` milliseconds.
+  Defaults to `5000` milliseconds.
 * `waitTimeout` - Number in milliseconds to wait for calls like
   `waitUntilTextExists` and `waitUntilWindowLoaded` to complete.
   Defaults to `5000` milliseconds.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Create a new application with the following options:
   Defaults to `9515`.
 * `quitTimeout` - Number in milliseconds to wait for application quitting.
   Defaults to `1000` milliseconds.
+* `startTimeout` - Number in milliseconds to wait for ChromeDriver to start.
+  Defaults to `10000` milliseconds.
 * `waitTimeout` - Number in milliseconds to wait for calls like
   `waitUntilTextExists` and `waitUntilWindowLoaded` to complete.
   Defaults to `5000` milliseconds.

--- a/lib/application.js
+++ b/lib/application.js
@@ -9,7 +9,7 @@ function Application (options) {
   this.host = options.host || '127.0.0.1'
   this.port = parseInt(options.port, 10) || 9515
   this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
-  this.startTimeout = parseInt(options.startTimeout, 10) || 10000
+  this.startTimeout = parseInt(options.startTimeout, 10) || 5000
   this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
 
   this.path = options.path

--- a/lib/application.js
+++ b/lib/application.js
@@ -9,6 +9,7 @@ function Application (options) {
   this.host = options.host || '127.0.0.1'
   this.port = parseInt(options.port, 10) || 9515
   this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
+  this.startTimeout = parseInt(options.startTimeout, 10) || 10000
   this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
 
   this.path = options.path
@@ -59,6 +60,7 @@ Application.prototype.exists = function () {
 
 Application.prototype.startChromeDriver = function () {
   var self = this
+  var startTime = Date.now()
 
   return new Promise(function (resolve, reject) {
     self.chromeDriver = new ChromeDriver(self.host, self.port)
@@ -67,6 +69,11 @@ Application.prototype.startChromeDriver = function () {
     var waitUntilRunning = function () {
       self.chromeDriver.isRunning(function (running) {
         if (running) return resolve()
+
+        var elapsedTime = Date.now() - startTime
+        if (elapsedTime > self.startTimeout)
+          return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
+
         setTimeout(waitUntilRunning, 100)
       })
     }

--- a/lib/application.js
+++ b/lib/application.js
@@ -59,26 +59,8 @@ Application.prototype.exists = function () {
 }
 
 Application.prototype.startChromeDriver = function () {
-  var self = this
-  var startTime = Date.now()
-
-  return new Promise(function (resolve, reject) {
-    self.chromeDriver = new ChromeDriver(self.host, self.port)
-    self.chromeDriver.start()
-
-    var waitUntilRunning = function () {
-      self.chromeDriver.isRunning(function (running) {
-        if (running) return resolve()
-
-        var elapsedTime = Date.now() - startTime
-        if (elapsedTime > self.startTimeout)
-          return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
-
-        setTimeout(waitUntilRunning, 100)
-      })
-    }
-    waitUntilRunning()
-  })
+  this.chromeDriver = new ChromeDriver(this.host, this.port, this.startTimeout)
+  return this.chromeDriver.start()
 }
 
 Application.prototype.createClient = function () {

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -46,8 +46,9 @@ ChromeDriver.prototype.waitUntilRunning = function () {
         if (running) return resolve()
 
         var elapsedTime = Date.now() - startTime
-        if (elapsedTime > self.startTimeout)
+        if (elapsedTime > self.startTimeout) {
           return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
+        }
 
         setTimeout(checkIfRunning, 100)
       })

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -43,7 +43,13 @@ ChromeDriver.prototype.waitUntilRunning = function () {
     var startTime = Date.now()
     var checkIfRunning = function () {
       self.isRunning(function (running) {
-        if (running) return resolve()
+        if (!self.process) {
+          return reject(Error('ChromeDriver has been stopped'))
+        }
+
+        if (running) {
+          return resolve()
+        }
 
         var elapsedTime = Date.now() - startTime
         if (elapsedTime > self.startTimeout) {

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -3,9 +3,10 @@ var path = require('path')
 var request = require('request')
 var split = require('split')
 
-function ChromeDriver (host, port) {
+function ChromeDriver (host, port, startTimeout) {
   this.host = host
   this.port = port
+  this.startTimeout = startTimeout
 
   this.path = require.resolve('electron-chromedriver/chromedriver')
   this.urlBase = '/wd/hub'
@@ -33,6 +34,26 @@ ChromeDriver.prototype.start = function () {
   global.process.on('exit', this.exitHandler)
 
   this.setupLogs()
+  return this.waitUntilRunning()
+}
+
+ChromeDriver.prototype.waitUntilRunning = function () {
+  var self = this
+  return new Promise(function (resolve, reject) {
+    var startTime = Date.now()
+    var checkIfRunning = function () {
+      self.isRunning(function (running) {
+        if (running) return resolve()
+
+        var elapsedTime = Date.now() - startTime
+        if (elapsedTime > self.startTimeout)
+          return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
+
+        setTimeout(checkIfRunning, 100)
+      })
+    }
+    checkIfRunning()
+  })
 }
 
 ChromeDriver.prototype.setupLogs = function () {

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -56,7 +56,7 @@ ChromeDriver.prototype.waitUntilRunning = function () {
           return reject(Error('ChromeDriver did not start within ' + self.startTimeout + 'ms'))
         }
 
-        setTimeout(checkIfRunning, 100)
+        global.setTimeout(checkIfRunning, 100)
       })
     }
     checkIfRunning()

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -74,6 +74,11 @@ describe('application loading', function () {
       return new Application({path: path.join(__dirname, 'invalid')})
         .start().should.be.rejectedWith(Error)
     })
+
+    it('rejects with an error if ChromeDriver does not start within the specified timeout', function () {
+      return new Application({path: helpers.getElectronPath(), host: 'bad.host', startTimeout: 1000})
+        .start().should.be.rejectedWith(Error, 'ChromeDriver did not start within 1000ms')
+    })
   })
 
   describe('stop()', function () {

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -76,8 +76,8 @@ describe('application loading', function () {
     })
 
     it('rejects with an error if ChromeDriver does not start within the specified timeout', function () {
-      return new Application({path: helpers.getElectronPath(), host: 'bad.host', startTimeout: 1000})
-        .start().should.be.rejectedWith(Error, 'ChromeDriver did not start within 1000ms')
+      return new Application({path: helpers.getElectronPath(), host: 'bad.host', startTimeout: 150})
+        .start().should.be.rejectedWith(Error, 'ChromeDriver did not start within 150ms')
     })
   })
 


### PR DESCRIPTION
This allows the ChromeDriver start timeout to be configured instead of infinitely polling and using the spec timeout to trigger killing ChromeDriver.

Refs #3 