### PR TITLE
Add nodePath config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Added a `startTimeout` config option to `Application` that sets the default
   millisecond timeout to wait for ChromeDriver to start up. This option
   defaults to 5 seconds.
+* Added a `nodePath` config option to `Application` that sets the path to a
+  `node` executable that will be used to launch the ChromeDriver startup
+  script.
 
 # 0.35.4
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Create a new application with the following options:
   Defaults to `'localhost'`.
 * `port` - Number port of the launched `chromedriver` process.
   Defaults to `9515`.
+* `nodePath` - String path to a `node` executable to launch ChromeDriver with.
+  Defaults to `process.execPath`.
 * `quitTimeout` - Number in milliseconds to wait for application quitting.
   Defaults to `1000` milliseconds.
 * `startTimeout` - Number in milliseconds to wait for ChromeDriver to start.

--- a/lib/application.js
+++ b/lib/application.js
@@ -11,6 +11,7 @@ function Application (options) {
   this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
   this.startTimeout = parseInt(options.startTimeout, 10) || 5000
   this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
+  this.nodePath = options.nodePath || process.execPath
 
   this.path = options.path
   this.args = options.args || []
@@ -59,7 +60,7 @@ Application.prototype.exists = function () {
 }
 
 Application.prototype.startChromeDriver = function () {
-  this.chromeDriver = new ChromeDriver(this.host, this.port, this.startTimeout)
+  this.chromeDriver = new ChromeDriver(this.host, this.port, this.nodePath, this.startTimeout)
   return this.chromeDriver.start()
 }
 

--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -3,9 +3,10 @@ var path = require('path')
 var request = require('request')
 var split = require('split')
 
-function ChromeDriver (host, port, startTimeout) {
+function ChromeDriver (host, port, nodePath, startTimeout) {
   this.host = host
   this.port = port
+  this.nodePath = nodePath
   this.startTimeout = startTimeout
 
   this.path = require.resolve('electron-chromedriver/chromedriver')
@@ -27,7 +28,7 @@ ChromeDriver.prototype.start = function () {
     cwd: process.cwd(),
     env: this.getEnvironment()
   }
-  this.process = ChildProcess.spawn(process.execPath, args, options)
+  this.process = ChildProcess.spawn(this.nodePath, args, options)
 
   var self = this
   this.exitHandler = function () { self.stop() }


### PR DESCRIPTION
Adds a `nodePath` config option to `Application` that will be used when spawning the ChromeDriver startup script. This is optional and will default to `process.execPath`.

Refs #3 