### PR TITLE
Upgrade to WebdriverIO 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 0.36.2
+# 1.37.0
 
-  * Upgraded to WebdriverIO 4.0.3
+  * Upgraded to WebdriverIO 4.0.4
   * Added a `connectionRetryCount` config option to `Application` that sets the
     default number of connection retries to make to ChromeDriver.
   * Added a `connectionRetryTimeout` config option to `Application` that sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.36.2
+
+  * Upgraded to WebdriverIO 4.0.3
+  * Added a `connectionRetryCount` config option to `Application` that sets the
+    default number of connection retries to make to ChromeDriver.
+  * Added a `connectionRetryTimeout` config option to `Application` that sets
+    the default number of milliseconds to wait when connecting to ChromeDriver.
+
 # 0.36.1
 
 * Added a `cwd` config option to `Application` that sets the working

--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ Create a new application with the following options:
 * `nodePath` - String path to a `node` executable to launch ChromeDriver with.
   Defaults to `process.execPath`.
 * `connectionRetryCount` - Number of retry attempts to make when connecting
-  to ChromeDriver. Defaults to `5` attempts.
+  to ChromeDriver. Defaults to `10` attempts.
 * `connectionRetryTimeout` - Number in milliseconds to wait for connections
-  to ChromeDriver to be made. Defaults to `90000` milliseconds.
+  to ChromeDriver to be made. Defaults to `30000` milliseconds.
 * `quitTimeout` - Number in milliseconds to wait for application quitting.
   Defaults to `1000` milliseconds.
 * `startTimeout` - Number in milliseconds to wait for ChromeDriver to start.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ Create a new application with the following options:
   Defaults to `9515`.
 * `nodePath` - String path to a `node` executable to launch ChromeDriver with.
   Defaults to `process.execPath`.
+* `connectionRetryCount` - Number of retry attempts to make when connecting
+  to ChromeDriver. Defaults to `5` attempts.
+* `connectionRetryTimeout` - Number in milliseconds to wait for connections
+  to ChromeDriver to be made. Defaults to `90000` milliseconds.
 * `quitTimeout` - Number in milliseconds to wait for application quitting.
   Defaults to `1000` milliseconds.
 * `startTimeout` - Number in milliseconds to wait for ChromeDriver to start.

--- a/lib/application.js
+++ b/lib/application.js
@@ -11,6 +11,8 @@ function Application (options) {
   this.quitTimeout = parseInt(options.quitTimeout, 10) || 1000
   this.startTimeout = parseInt(options.startTimeout, 10) || 5000
   this.waitTimeout = parseInt(options.waitTimeout, 10) || 5000
+  this.connectionRetryCount = parseInt(options.connectionRetryCount, 10) || 10
+  this.connectionRetryTimeout = parseInt(options.connectionRetryTimeout, 10) || 30000
   this.nodePath = options.nodePath || process.execPath
 
   this.path = options.path
@@ -93,6 +95,8 @@ Application.prototype.createClient = function () {
       host: self.host,
       port: self.port,
       waitforTimeout: self.waitTimeout,
+      connectionRetryCount: self.connectionRetryCount,
+      connectionRetryTimeout: self.connectionRetryTimeout,
       desiredCapabilities: {
         browserName: 'electron',
         chromeOptions: {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron-prebuilt": "^0.36.9",
+    "electron-prebuilt": "^0.37.2",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron-chromedriver": "^0.37.1",
     "request": "^2.65.0",
     "split": "^1.0.0",
-    "webdriverio": "^4.0.3"
+    "webdriverio": "^4.0.4"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron-chromedriver": "^0.37.1",
     "request": "^2.65.0",
     "split": "^1.0.0",
-    "webdriverio": "^3.2.6"
+    "webdriverio": "^4.0.3"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron-prebuilt": "^0.36.0",
+    "electron-prebuilt": "^0.36.9",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"


### PR DESCRIPTION
Upgrades to a new major WebdriverIO version which has some new connection retry/timeout options that should help issues around occasional `Couldn't connect to selenium server` errors.