### PR TITLE
Upgrade to Electron 0.37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 appveyor.yml
 .npmignore
 script
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/kevinsawicki/spectron#readme",
   "dependencies": {
     "dev-null": "^0.1.1",
-    "electron-chromedriver": "^0.36.0",
+    "electron-chromedriver": "^0.37.1",
     "request": "^2.65.0",
     "split": "^1.0.0",
     "webdriverio": "^3.2.6"


### PR DESCRIPTION
This pull request upgrades spectron to Electron 0.37 which runs on Chrome 49.