### PR TITLE
Add getAppPath helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.37.1
+
+  * Add the `getAppPath(name)` that maps to the
+    `require('electron').app.getPath(name)` API.
+
 # 1.37.0
 
   * Upgraded to WebdriverIO 4.0.4

--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ Several additional commands are provided specific to Electron.
 
 All the commands return a `Promise`.
 
+#### getAppPath(name)
+
+Get the path using `require('electron').app.getPath(name)` API.
+
+```js
+app.client.getAppPath('userData').then(function (userDataPath) {
+  console.log(userDataPath)
+})
+```
+
 #### getArgv()
 
 Get the `argv` array from the main process.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ All the commands return a `Promise`.
 
 #### getAppPath(name)
 
-Get the path using `require('electron').app.getPath(name)` API.
+Get the path using the `require('electron').app.getPath(name)` API.
 
 ```js
 app.client.getAppPath('userData').then(function (userDataPath) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -176,6 +176,12 @@ Application.prototype.addCommands = function () {
     })
   })
 
+  this.client.addCommand('getAppPath', function (pathName) {
+    return this.execute(function (pathName) {
+      return require('electron').remote.app.getPath(pathName)
+    }, pathName).then(getResponseValue)
+  })
+
   this.client.addCommand('waitUntilWindowLoaded', function (timeout) {
     return this.waitUntil(function () {
       return this.isWindowLoading().then(function (loading) {

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -161,12 +161,4 @@ describe('application loading', function () {
         .getMainProcessGlobal('mainProcessGlobal').should.eventually.equal('foo')
     })
   })
-
-  describe('getAppPath', function () {
-    it('returns the path for the given name', function () {
-      return app.client.getAppPath('temp').then(function (tempPath) {
-        return path.resolve(tempPath)
-      }).should.eventually.equal(temp.dir)
-    })
-  })
 })

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -163,9 +163,10 @@ describe('application loading', function () {
   })
 
   describe('getAppPath', function () {
-    it.only('returns the path for the given name', function () {
-      return app.client
-        .getAppPath('temp').should.eventually.equal(temp.dir + path.sep)
+    it('returns the path for the given name', function () {
+      return app.client.getAppPath('temp').then(function (tempPath) {
+        return path.resolve(tempPath)
+      }).should.eventually.equal(temp.dir)
     })
   })
 })

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -161,4 +161,11 @@ describe('application loading', function () {
         .getMainProcessGlobal('mainProcessGlobal').should.eventually.equal('foo')
     })
   })
+
+  describe('getAppPath', function () {
+    it.only('returns the path for the given name', function () {
+      return app.client
+        .getAppPath('temp').should.eventually.equal(temp.dir + path.sep)
+    })
+  })
 })

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -1,5 +1,6 @@
 var helpers = require('./global-setup')
 var path = require('path')
+var temp = require('temp').track()
 
 var describe = global.describe
 var it = global.it
@@ -167,6 +168,14 @@ describe('window commands', function () {
         .getRepresentedFilename().should.eventually.equal('')
         .setRepresentedFilename('/foo.js')
         .getRepresentedFilename().should.eventually.equal('/foo.js')
+    })
+  })
+
+  describe('getAppPath', function () {
+    it('returns the path for the given name', function () {
+      return app.client.getAppPath('temp').then(function (tempPath) {
+        return path.resolve(tempPath)
+      }).should.eventually.equal(temp.dir)
     })
   })
 


### PR DESCRIPTION
Maps to `require('electron').app.getPath(name)`.

http://electron.atom.io/docs/latest/api/app/#appgetpathname

Closes #16 